### PR TITLE
feat: serve wrl 3d models

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
 # @tscircuit/kicad-mod-server
 
-This server serves the kicad mod files using the git repository
+This server serves the kicad mod files using the git repository, and now also
+serves wrl 3D model files from the official
+[kicad-packages3D](https://gitlab.com/kicad/libraries/kicad-packages3D)
+repository.
 
 | Endpoint            | Description             |
 | ------------------- | ----------------------- |
 | `/kicad_files.json` | List of all kicad files |
 | `/*.kicad_mod`      | Get a kicad mod file    |
+| `/*.wrl`            | Get a 3D model file     |
 
 ## License
 

--- a/app/[...anypath]/cors.ts
+++ b/app/[...anypath]/cors.ts
@@ -1,0 +1,37 @@
+export const buildCorsHeaders = (
+  req: Request,
+  contentType: string,
+): Headers => {
+  const headers = new Headers()
+  headers.set("Cache-Control", "s-maxage=86400, stale-while-revalidate=86400")
+  headers.set("Content-Type", contentType)
+
+  const origin = req.headers.get("origin") || "*"
+  headers.set("Access-Control-Allow-Origin", origin)
+  headers.set("Access-Control-Allow-Methods", "GET, OPTIONS")
+  headers.set("Access-Control-Allow-Headers", "Content-Type")
+  headers.set("Vary", "Origin")
+
+  return headers
+}
+
+export const handleOptions = (req: Request): Response => {
+  const headers = new Headers()
+  const origin = req.headers.get("origin") || "*"
+  const reqMethod = req.headers.get("access-control-request-method") || "GET"
+  const reqHeaders =
+    req.headers.get("access-control-request-headers") || "Content-Type"
+
+  headers.set("Access-Control-Allow-Origin", origin)
+  headers.set("Access-Control-Allow-Methods", `${reqMethod}, OPTIONS`)
+  headers.set("Access-Control-Allow-Headers", reqHeaders)
+  headers.set("Access-Control-Max-Age", "86400")
+  headers.set(
+    "Vary",
+    "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+  )
+
+  headers.set("Access-Control-Allow-Private-Network", "true")
+
+  return new Response(null, { status: 204, headers })
+}

--- a/app/[...anypath]/fetch-file.ts
+++ b/app/[...anypath]/fetch-file.ts
@@ -1,0 +1,99 @@
+import {
+  convertKicadModToCircuitJson,
+  isValidKicadMod,
+} from "../../lib/kicad-converter"
+
+export interface FetchResult {
+  body: string
+  contentType: string
+  status: number
+}
+
+export const fetchFile = async (pathname: string): Promise<FetchResult> => {
+  const convertToCircuitJson = pathname.endsWith(".circuit.json")
+  const isKicadMod = pathname.endsWith("kicad_mod")
+  const isWrl = pathname.endsWith(".wrl")
+
+  if (!isKicadMod && !convertToCircuitJson && !isWrl) {
+    return {
+      body: "Invalid path parameter",
+      contentType: "text/plain",
+      status: 400,
+    }
+  }
+
+  let fetchPath = convertToCircuitJson
+    ? pathname.replace(".circuit.json", ".kicad_mod")
+    : pathname
+
+  let gitlabUrl = ""
+  let contentType = "text/plain"
+
+  if (isKicadMod || convertToCircuitJson) {
+    const parts = fetchPath.split("/")
+    if (parts.length >= 3) {
+      const firstSegmentIndex = 1
+      if (
+        parts[firstSegmentIndex] &&
+        !parts[firstSegmentIndex].endsWith(".pretty")
+      ) {
+        parts[firstSegmentIndex] = `${parts[firstSegmentIndex]}.pretty`
+        fetchPath = parts.join("/")
+      }
+    }
+
+    gitlabUrl = `https://gitlab.com/kicad/libraries/kicad-footprints/-/raw/master${fetchPath}?ref_type=heads`
+  } else if (isWrl) {
+    const parts = fetchPath.split("/")
+    if (parts.length >= 3) {
+      const firstSegmentIndex = 1
+      if (
+        parts[firstSegmentIndex] &&
+        !parts[firstSegmentIndex].endsWith(".3dshapes")
+      ) {
+        parts[firstSegmentIndex] = `${parts[firstSegmentIndex]}.3dshapes`
+        fetchPath = parts.join("/")
+      }
+    }
+
+    gitlabUrl = `https://gitlab.com/kicad/libraries/kicad-packages3D/-/raw/master${fetchPath}?ref_type=heads`
+    contentType = "model/vrml"
+  }
+
+  const res = await fetch(gitlabUrl)
+
+  if (!res.ok) {
+    return {
+      body: "Couldn't find file",
+      contentType: "text/plain",
+      status: res.status,
+    }
+  }
+
+  let responseContent = await res.text()
+
+  if (convertToCircuitJson) {
+    if (!isValidKicadMod(responseContent)) {
+      return {
+        body: "Invalid KiCad mod file format",
+        contentType: "text/plain",
+        status: 400,
+      }
+    }
+
+    const conversionResult = await convertKicadModToCircuitJson(responseContent)
+
+    if (!conversionResult.success) {
+      return {
+        body: `Conversion error: ${conversionResult.error}`,
+        contentType: "text/plain",
+        status: 500,
+      }
+    }
+
+    responseContent = JSON.stringify(conversionResult.data, null, 2)
+    contentType = "application/json"
+  }
+
+  return { body: responseContent, contentType, status: 200 }
+}

--- a/app/[...anypath]/route.ts
+++ b/app/[...anypath]/route.ts
@@ -1,110 +1,17 @@
-import {
-	convertKicadModToCircuitJson,
-	isValidKicadMod,
-} from "../../lib/kicad-converter";
+import { fetchFile } from "./fetch-file"
+import { buildCorsHeaders, handleOptions } from "./cors"
 
 export const GET = async (req: Request) => {
-	const { pathname, searchParams } = new URL(req.url);
+  const { pathname } = new URL(req.url)
 
-	// Check if the parameter is provided
-	if (!pathname) {
-		return new Response("Missing path parameter", { status: 400 });
-	}
+  if (!pathname) {
+    return new Response("Missing path parameter", { status: 400 })
+  }
 
-	// Check if circuit.json conversion is requested
-	const convertToCircuitJson = pathname.endsWith(".circuit.json");
+  const { body, contentType, status } = await fetchFile(pathname)
+  const headers = buildCorsHeaders(req, contentType)
 
-	// Validate path parameter
-	if (!pathname.endsWith("kicad_mod") && !pathname.endsWith(".circuit.json")) {
-		return new Response("Invalid path parameter", { status: 400 });
-	}
+  return new Response(body, { status, headers })
+}
 
-	// Convert .circuit.json path to .kicad_mod for fetching
-	let kicadModPath = convertToCircuitJson
-		? pathname.replace(".circuit.json", ".kicad_mod")
-		: pathname;
-
-	// Support folder paths without the ".pretty" suffix by normalizing the first segment
-	// Example: /Resistor_SMD/R_0402_1005Metric.kicad_mod -> /Resistor_SMD.pretty/R_0402_1005Metric.kicad_mod
-	const parts = kicadModPath.split("/");
-	if (parts.length >= 3) {
-		const firstSegmentIndex = 1; // because split on leading "/" yields first empty string
-		if (parts[firstSegmentIndex] && !parts[firstSegmentIndex].endsWith(".pretty")) {
-			parts[firstSegmentIndex] = `${parts[firstSegmentIndex]}.pretty`;
-			kicadModPath = parts.join("/");
-		}
-	}
-
-	// Construct the GitLab URL using the extracted parameter
-	const gitlabUrl = `https://gitlab.com/kicad/libraries/kicad-footprints/-/raw/master${kicadModPath}?ref_type=heads`;
-
-	// Fetch the content from GitLab
-	const res = await fetch(gitlabUrl);
-
-	// Check if the fetch was successful
-	if (!res.ok) {
-		return new Response("Couldn't find file", { status: res.status });
-	}
-
-	const kicadModContent = await res.text();
-
-	let responseContent = kicadModContent;
-	let contentType = "text/plain";
-
-	// Convert to circuit.json if requested
-	if (convertToCircuitJson) {
-		if (!isValidKicadMod(kicadModContent)) {
-			return new Response("Invalid KiCad mod file format", { status: 400 });
-		}
-
-		const conversionResult = await convertKicadModToCircuitJson(kicadModContent);
-
-		if (!conversionResult.success) {
-			return new Response(`Conversion error: ${conversionResult.error}`, {
-				status: 500,
-			});
-		}
-
-		responseContent = JSON.stringify(conversionResult.data, null, 2);
-		contentType = "application/json";
-	}
-
-    const headers = new Headers();
-    headers.set("Cache-Control", "s-maxage=86400, stale-while-revalidate=86400");
-    headers.set("Content-Type", contentType);
-
-    // CORS headers
-    const origin = req.headers.get("origin") || "*";
-    headers.set("Access-Control-Allow-Origin", origin);
-    headers.set("Access-Control-Allow-Methods", "GET, OPTIONS");
-    headers.set("Access-Control-Allow-Headers", "Content-Type");
-    headers.set("Vary", "Origin");
-
-	// Return the response with caching and CORS headers
-	return new Response(responseContent, {
-		status: 200,
-		headers: headers,
-	});
-};
-
-export const OPTIONS = async (req: Request) => {
-    // Preflight CORS handling
-    const headers = new Headers();
-    const origin = req.headers.get("origin") || "*";
-    const reqMethod = req.headers.get("access-control-request-method") || "GET";
-    const reqHeaders = req.headers.get("access-control-request-headers") || "Content-Type";
-
-    headers.set("Access-Control-Allow-Origin", origin);
-    headers.set("Access-Control-Allow-Methods", `${reqMethod}, OPTIONS`);
-    headers.set("Access-Control-Allow-Headers", reqHeaders);
-    headers.set("Access-Control-Max-Age", "86400");
-    headers.set("Vary", "Origin, Access-Control-Request-Method, Access-Control-Request-Headers");
-
-    // Only needed for Private Network Access preflight (Chrome-based)
-    headers.set("Access-Control-Allow-Private-Network", "true");
-
-    return new Response(null, {
-        status: 204,
-        headers,
-    });
-};
+export const OPTIONS = (req: Request) => handleOptions(req)

--- a/app/route.ts
+++ b/app/route.ts
@@ -10,16 +10,20 @@ export const GET = (req: Request) => {
 
   return new Response(
     `<html><body>
-  
-  This server caches official kicad mod files, here is the <a href="https://gitlab.com/kicad/libraries/kicad-footprints/-/blob/master/LICENSE.md?ref_type=heads">license file</a> and <a href="https://gitlab.com/kicad/libraries/kicad-footprints">original repo</a>
+
+  This server caches official kicad mod and 3D model (wrl) files.<br/>
+  Footprints: <a href="https://gitlab.com/kicad/libraries/kicad-footprints/-/blob/master/LICENSE.md?ref_type=heads">license file</a> and <a href="https://gitlab.com/kicad/libraries/kicad-footprints">original repo</a><br/>
+  3D models: <a href="https://gitlab.com/kicad/libraries/kicad-packages3D/-/blob/master/LICENSE.md?ref_type=heads">license file</a> and <a href="https://gitlab.com/kicad/libraries/kicad-packages3D">original repo</a>
     <p>
-    Example URL: <a href="/Resistor_SMD/R_0402_1005Metric.kicad_mod">/Resistor_SMD/R_0402_1005Metric.kicad_mod</a>
+    Example footprint: <a href="/Resistor_SMD/R_0402_1005Metric.kicad_mod">/Resistor_SMD/R_0402_1005Metric.kicad_mod</a>
     </p>
     <p>
-    You can also load the circuit json equivalent of the mod file by replacing the .kicad_mod with .circuit.json
-    <a href="/Resistor_SMD/R_0402_1005Metric.circuit.json">/Resistor_SMD/R_0402_1005Metric.circuit.json</a>
+    Example circuit json: <a href="/Resistor_SMD/R_0402_1005Metric.circuit.json">/Resistor_SMD/R_0402_1005Metric.circuit.json</a>
     </p>
-  
+    <p>
+    Example 3D model: <a href="/Battery/BatteryClip.wrl">/Battery/BatteryClip.wrl</a>
+    </p>
+
   </body></html>`,
     {
       headers,

--- a/package.json
+++ b/package.json
@@ -8,17 +8,18 @@
     "pull-kicad-footprints": "git clone --depth 1 https://gitlab.com/kicad/libraries/kicad-footprints.git",
     "move-to-public-dir": "rm -rf public && mkdir -p ./public/kicad-footprints && cp -r ./kicad-footprints/*.pretty ./public/kicad-footprints/",
     "write-index-file": "make-vfs ./public/kicad-footprints --content-format string --outfile ./vfs.js && node write-index-file.js",
-    "start": "next dev"
+    "start": "next dev",
+    "format": "biome format . --write"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@biomejs/biome": "^2.1.2",
     "kicad-component-converter": "^0.1.10",
     "make-vfs": "^1.0.10"
   },
   "devDependencies": {
+    "@biomejs/biome": "^2.2.3",
     "@types/node": "20.12.12",
     "@types/react": "18.3.3",
     "next": "^14.2.3",

--- a/public/index.html
+++ b/public/index.html
@@ -1,15 +1,6 @@
-const fs = await import("fs")
-const vfs = (await import("./vfs.js")).default
-
-const filepaths = Object.keys(vfs)
-
-fs.writeFileSync("public/kicad_files.json", JSON.stringify(filepaths))
-fs.writeFileSync(
-  "public/index.html",
-  `<html><body>
+<html><body>
 
 This server hosts official kicad mod and 3d model (wrl) files. Footprints: <a href="https://gitlab.com/kicad/libraries/kicad-footprints/-/blob/master/LICENSE.md?ref_type=heads">license file</a> and <a href="https://gitlab.com/kicad/libraries/kicad-footprints">original repo</a><br/>
 3D models: <a href="https://gitlab.com/kicad/libraries/kicad-packages3D/-/blob/master/LICENSE.md?ref_type=heads">license file</a> and <a href="https://gitlab.com/kicad/libraries/kicad-packages3D">original repo</a>
 
-</body></html>`,
-)
+</body></html>

--- a/tests/wrl-serving.test.ts
+++ b/tests/wrl-serving.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "bun:test"
+import { GET } from "../app/[...anypath]/route"
+
+test("serves wrl files from packages3D repo", async () => {
+  const expectedUrl =
+    "https://gitlab.com/kicad/libraries/kicad-packages3D/-/raw/master/Battery.3dshapes/BatteryClip.wrl?ref_type=heads"
+  const originalFetch = global.fetch
+  global.fetch = (async (url: RequestInfo) => {
+    expect(url).toBe(expectedUrl)
+    return new Response("wrl content")
+  }) as any
+
+  const req = new Request("http://localhost/Battery/BatteryClip.wrl")
+  const res = await GET(req)
+  const text = await res.text()
+
+  expect(text).toBe("wrl content")
+  expect(res.headers.get("Content-Type")).toBe("model/vrml")
+
+  global.fetch = originalFetch
+})


### PR DESCRIPTION
## Summary
- serve WRL 3D model files from the kicad-packages3D repo
- document availability of 3D models on the index page
- test WRL route handling
- modularize wildcard route logic and add biome formatter script

## Testing
- `bun test tests`
- `bun run format` *(warns about public/kicad_files.json exceeding max size)*

------
https://chatgpt.com/codex/tasks/task_b_68bf6ba3de74832ea4af5a78778a8f3c