### PR TITLE
Fix KiCad 3D models by falling back to STEP

### DIFF
--- a/app/[...anypath]/fetch-file.ts
+++ b/app/[...anypath]/fetch-file.ts
@@ -13,8 +13,9 @@ export const fetchFile = async (pathname: string): Promise<FetchResult> => {
   const convertToCircuitJson = pathname.endsWith(".circuit.json")
   const isKicadMod = pathname.endsWith("kicad_mod")
   const isWrl = pathname.endsWith(".wrl")
+  const isStep = pathname.endsWith(".step")
 
-  if (!isKicadMod && !convertToCircuitJson && !isWrl) {
+  if (!isKicadMod && !convertToCircuitJson && !isWrl && !isStep) {
     return {
       body: "Invalid path parameter",
       contentType: "text/plain",
@@ -48,7 +49,7 @@ export const fetchFile = async (pathname: string): Promise<FetchResult> => {
 
     gitlabBaseUrl =
       "https://gitlab.com/kicad/libraries/kicad-footprints/-/raw/master"
-  } else if (isWrl) {
+  } else if (isWrl || isStep) {
     const parts = requestedPath.split("/")
     const with3dShapes = [...parts]
     if (parts.length >= 3) {
@@ -66,7 +67,7 @@ export const fetchFile = async (pathname: string): Promise<FetchResult> => {
 
     gitlabBaseUrl =
       "https://gitlab.com/kicad/libraries/kicad-packages3D/-/raw/master"
-    contentType = "model/vrml"
+    contentType = isWrl ? "model/vrml" : "model/step"
   }
 
   const uniqueCandidates = [...new Set(fetchPathCandidates)]

--- a/app/[...anypath]/fetch-file.ts
+++ b/app/[...anypath]/fetch-file.ts
@@ -49,7 +49,7 @@ export const fetchFile = async (pathname: string): Promise<FetchResult> => {
 
     gitlabBaseUrl =
       "https://gitlab.com/kicad/libraries/kicad-footprints/-/raw/master"
-  } else if (isWrl || isStep) {
+  } else if (isWrl) {
     const parts = requestedPath.split("/")
     const with3dShapes = [...parts]
     if (parts.length >= 3) {
@@ -67,7 +67,26 @@ export const fetchFile = async (pathname: string): Promise<FetchResult> => {
 
     gitlabBaseUrl =
       "https://gitlab.com/kicad/libraries/kicad-packages3D/-/raw/master"
-    contentType = isWrl ? "model/vrml" : "model/step"
+    contentType = "model/vrml"
+  } else if (isStep) {
+    const parts = requestedPath.split("/")
+    const with3dShapes = [...parts]
+    if (parts.length >= 3) {
+      const firstSegmentIndex = 1
+      if (
+        with3dShapes[firstSegmentIndex] &&
+        !with3dShapes[firstSegmentIndex].endsWith(".3dshapes")
+      ) {
+        with3dShapes[firstSegmentIndex] =
+          `${with3dShapes[firstSegmentIndex]}.3dshapes`
+      }
+    }
+
+    fetchPathCandidates = [with3dShapes.join("/"), requestedPath]
+
+    gitlabBaseUrl =
+      "https://gitlab.com/kicad/libraries/kicad-packages3D/-/raw/master"
+    contentType = "model/step"
   }
 
   const uniqueCandidates = [...new Set(fetchPathCandidates)]

--- a/tests/wrl-serving.test.ts
+++ b/tests/wrl-serving.test.ts
@@ -20,6 +20,25 @@ test("serves wrl files from packages3D repo", async () => {
   global.fetch = originalFetch
 })
 
+test("serves step files from packages3D repo", async () => {
+  const expectedUrl =
+    "https://gitlab.com/kicad/libraries/kicad-packages3D/-/raw/master/Battery.3dshapes/BatteryClip.step?ref_type=heads"
+  const originalFetch = global.fetch
+  global.fetch = (async (url: string | URL) => {
+    expect(url).toBe(expectedUrl)
+    return new Response("step content")
+  }) as any
+
+  const req = new Request("http://localhost/Battery/BatteryClip.step")
+  const res = await GET(req)
+  const text = await res.text()
+
+  expect(text).toBe("step content")
+  expect(res.headers.get("Content-Type")).toBe("model/step")
+
+  global.fetch = originalFetch
+})
+
 test("falls back to raw path if .pretty expansion 404s", async () => {
   const originalFetch = global.fetch
   const requests: string[] = []


### PR DESCRIPTION
**Motivation**: When a user uses kicad-footprint a 404 on the WRL URL shouldn’t block rendering when a STEP model is available.

**Fix**: 
KiCad footprints were failing to render in 3D because the viewer only tried the .wrl URL, which often returns 404. This change adds a safe fallback to .step so models still load when WRL is missing.


<img width="557" height="49" alt="Screenshot 2026-04-10 at 2 36 47 PM" src="https://github.com/user-attachments/assets/ecf42801-0418-4fc4-b23a-0c97d437de80" />

<img width="819" height="539" alt="Screenshot 2026-04-10 at 2 36 56 PM" src="https://github.com/user-attachments/assets/50921771-b18d-48ec-9c9e-f4251b4849ab" />

<img width="834" height="572" alt="Screenshot 2026-04-10 at 2 37 22 PM" src="https://github.com/user-attachments/assets/9a185da8-b35e-41fb-b17b-1b54beb5bf0b" />


