### PR TITLE
Fix KiCad footprint to circuit.json conversion using kicad-to-circuit-json

### DIFF
--- a/lib/kicad-converter.ts
+++ b/lib/kicad-converter.ts
@@ -1,4 +1,4 @@
-import { parseKicadModToCircuitJson } from "kicad-component-converter"
+import { KicadFootprintToCircuitJsonConverter } from "kicad-to-circuit-json"
 
 /**
  * Converts KiCad mod file content to circuit.json format
@@ -10,7 +10,11 @@ export async function convertKicadModToCircuitJson(kicadModContent: string) {
       throw new Error("Empty content provided")
     }
 
-    const circuitJson = await parseKicadModToCircuitJson(kicadModContent)
+    const converter = new KicadFootprintToCircuitJsonConverter()
+    converter.addFile("footprint.kicad_mod", kicadModContent)
+    converter.runUntilFinished()
+
+    const circuitJson = converter.getOutput()
     return {
       success: true,
       data: circuitJson,

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "kicad-component-converter": "^0.1.40",
+    "kicad-to-circuit-json": "^0.0.96",
+    "kicadts": "^0.0.44",
     "make-vfs": "^1.0.10"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@tscircuit/circuit-json-util": "^0.0.94",
     "kicad-to-circuit-json": "^0.0.96",
     "kicadts": "^0.0.44",
     "make-vfs": "^1.0.10"

--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
   "packageRules": [
     {
       "packagePatterns": ["*"],
-      "excludePackagePatterns": ["@tscircuit/*", "kicad-component-converter"],
+      "excludePackagePatterns": ["@tscircuit/*", "kicad-to-circuit-json"],
       "enabled": false
     },
     {

--- a/tests/kicad-converter.test.ts
+++ b/tests/kicad-converter.test.ts
@@ -4,16 +4,19 @@ import {
   isValidKicadMod,
 } from "../lib/kicad-converter"
 
-const validKicadModContent = `(module LED_SMD:LED_0603_1608Metric_Castellated (layer F.Cu) (tedit 5A030A40)
+const validKicadModContent = `(footprint "LED_SMD:LED_0603_1608Metric_Castellated" (version 20221018) (generator "kicad-footprint-generator")
+  (layer "F.Cu")
   (descr "LED SMD 0603 (1608 Metric), castellated end terminals, https://www.osram-os.com/Graphics/XPic4/00205340_0.pdf/KW%20CSLNM1.EC")
   (tags "LED castellated")
   (attr smd)
-  (fp_text reference REF** (at 0 -1.43) (layer F.SilkS)
+  (fp_text reference "REF**" (at 0 -1.43) (layer "F.SilkS")
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (fp_text value LED_0603_1608Metric_Castellated (at 0 1.43) (layer F.Fab)
+  (fp_text value "LED_0603_1608Metric_Castellated" (at 0 1.43) (layer "F.Fab")
     (effects (font (size 1 1) (thickness 0.15)))
   )
+  (pad "1" smd roundrect (at -0.8 0) (size 0.8 0.95) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25))
+  (pad "2" smd roundrect (at 0.8 0) (size 0.8 0.95) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25))
 )`
 
 const invalidKicadModContent = `This is not a valid KiCad mod file`
@@ -41,9 +44,6 @@ test("convertKicadModToCircuitJson should return success for valid content", asy
   expect(result.data).toBeDefined()
   expect(result.error).toBe(null)
 })
-
-// Note: The kicad-mod-converter library has some edge cases with error handling
-// These tests focus on the validation and successful conversion paths
 
 test("convertKicadModToCircuitJson should handle empty content", async () => {
   const result = await convertKicadModToCircuitJson("")


### PR DESCRIPTION
## Summary

Replaces the deprecated KiCad footprint conversion path with the actively maintained kicad-to-circuit-json converter.

## What changed

- Uses KicadFootprintToCircuitJsonConverter for .kicad_mod to circuit.json conversion
- Adds the required kicadts runtime dependency used by the converter
- Updates the converter regression test to use modern KiCad footprint syntax with pads
- Keeps the existing endpoint response shape unchanged
- Removes the deprecated converter package from dependency and Renovate metadata

## Why

The previous converter package is deprecated, leaving the circuit.json endpoint tied to an unsupported conversion path. This change moves footprint conversion to the maintained KiCad converter and verifies successful conversion with a real footprint-style fixture.

## Testing

- bun test
- bunx tsc --noEmit