### PR TITLE
Revert "Fix KiCad footprint to circuit.json conversion using kicad-to-circuit-json"

### DIFF
--- a/lib/kicad-converter.ts
+++ b/lib/kicad-converter.ts
@@ -1,4 +1,4 @@
-import { KicadFootprintToCircuitJsonConverter } from "kicad-to-circuit-json"
+import { parseKicadModToCircuitJson } from "kicad-component-converter"
 
 /**
  * Converts KiCad mod file content to circuit.json format
@@ -10,11 +10,7 @@ export async function convertKicadModToCircuitJson(kicadModContent: string) {
       throw new Error("Empty content provided")
     }
 
-    const converter = new KicadFootprintToCircuitJsonConverter()
-    converter.addFile("footprint.kicad_mod", kicadModContent)
-    converter.runUntilFinished()
-
-    const circuitJson = converter.getOutput()
+    const circuitJson = await parseKicadModToCircuitJson(kicadModContent)
     return {
       success: true,
       data: circuitJson,

--- a/package.json
+++ b/package.json
@@ -15,9 +15,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@tscircuit/circuit-json-util": "^0.0.94",
-    "kicad-to-circuit-json": "^0.0.96",
-    "kicadts": "^0.0.44",
+    "kicad-component-converter": "^0.1.40",
     "make-vfs": "^1.0.10"
   },
   "devDependencies": {

--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
   "packageRules": [
     {
       "packagePatterns": ["*"],
-      "excludePackagePatterns": ["@tscircuit/*", "kicad-to-circuit-json"],
+      "excludePackagePatterns": ["@tscircuit/*", "kicad-component-converter"],
       "enabled": false
     },
     {

--- a/tests/kicad-converter.test.ts
+++ b/tests/kicad-converter.test.ts
@@ -4,19 +4,16 @@ import {
   isValidKicadMod,
 } from "../lib/kicad-converter"
 
-const validKicadModContent = `(footprint "LED_SMD:LED_0603_1608Metric_Castellated" (version 20221018) (generator "kicad-footprint-generator")
-  (layer "F.Cu")
+const validKicadModContent = `(module LED_SMD:LED_0603_1608Metric_Castellated (layer F.Cu) (tedit 5A030A40)
   (descr "LED SMD 0603 (1608 Metric), castellated end terminals, https://www.osram-os.com/Graphics/XPic4/00205340_0.pdf/KW%20CSLNM1.EC")
   (tags "LED castellated")
   (attr smd)
-  (fp_text reference "REF**" (at 0 -1.43) (layer "F.SilkS")
+  (fp_text reference REF** (at 0 -1.43) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (fp_text value "LED_0603_1608Metric_Castellated" (at 0 1.43) (layer "F.Fab")
+  (fp_text value LED_0603_1608Metric_Castellated (at 0 1.43) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (pad "1" smd roundrect (at -0.8 0) (size 0.8 0.95) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25))
-  (pad "2" smd roundrect (at 0.8 0) (size 0.8 0.95) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25))
 )`
 
 const invalidKicadModContent = `This is not a valid KiCad mod file`
@@ -44,6 +41,9 @@ test("convertKicadModToCircuitJson should return success for valid content", asy
   expect(result.data).toBeDefined()
   expect(result.error).toBe(null)
 })
+
+// Note: The kicad-mod-converter library has some edge cases with error handling
+// These tests focus on the validation and successful conversion paths
 
 test("convertKicadModToCircuitJson should handle empty content", async () => {
   const result = await convertKicadModToCircuitJson("")


### PR DESCRIPTION
Reverts tscircuit/kicad-mod-cache#22

@rushabhcodes this is breaking the eval tests